### PR TITLE
feat: atomicfile package creates files atomically

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,18 @@
 [![codecov](https://codecov.io/gh/gammazero/fsutil/graph/badge.svg?token=U2Y5KBC0H3)](https://codecov.io/gh/gammazero/fsutil)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-Filesystem utility for common file and directory checks. The [`fsutil/disk`](https://pkg.go.dev/github.com/gammazero/fsutil/disk) package provides functionality for reporting disk usage on multiple platforms.
+Filesystem utility for common file and directory checks.
+
+## Packages
+
+### [fsutil](https://pkg.go.dev/github.com/gammazero/fsutil)
+
+Common file and directory checks: `DirEmpty`, `DirExists`, `DirWritable`, `ExpandHome`, `FileChanged`, `FileExists`.
+
+### [fsutil/atomicfile](https://pkg.go.dev/github.com/gammazero/fsutil/atomicfile)
+
+Creates a temporary file that is renamed to the specified path when `Close` is called. This prevents a partially written file from being visible when writes are in progress or when a failure occurs during writing.
+
+### [fsutil/disk](https://pkg.go.dev/github.com/gammazero/fsutil/disk)
+
+Reports disk usage on multiple platforms: aix, darwin (macOS), freebsd, linux, openbsd, windows.

--- a/atomicfile/atomicfile.go
+++ b/atomicfile/atomicfile.go
@@ -1,0 +1,64 @@
+package atomicfile
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+// File is an os.File that does an atomic rename when [Close] is called.
+type File struct {
+	*os.File
+	path string
+}
+
+// Create creates a new temporary file at the given path, opens the file for
+// reading and writing, and returns the resulting file. The temporary file is
+// renamed to the given path when [Close] is called.
+func Create(path string, mode os.FileMode) (*File, error) {
+	f, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path))
+	if err != nil {
+		return nil, err
+	}
+	if err = os.Chmod(f.Name(), mode); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return nil, err
+	}
+	return &File{
+		File: f,
+		path: path,
+	}, nil
+}
+
+// Close closes the file and renames it to the final name.
+func (f *File) Close() error {
+	err := f.File.Close()
+	if err != nil {
+		if errors.Is(err, os.ErrClosed) {
+			_ = os.Remove(f.TempName())
+		}
+		return err
+	}
+
+	return os.Rename(f.TempName(), f.Name())
+}
+
+// Discard closes the temproary file and removes it without renaming it.
+func (f *File) Discard() error {
+	if err := f.File.Close(); err != nil {
+		_ = os.Remove(f.TempName())
+		return err
+	}
+	return os.Remove(f.TempName())
+}
+
+// Name returns the final name of the file.
+func (f *File) Name() string {
+	return f.path
+}
+
+// TempName returns the temporary name of the file.
+func (f *File) TempName() string {
+	return f.File.Name()
+}

--- a/atomicfile/atomicfile.go
+++ b/atomicfile/atomicfile.go
@@ -35,7 +35,8 @@ func Create(path string, mode os.FileMode) (*File, error) {
 func (f *File) Close() error {
 	err := f.File.Close()
 	if err != nil {
-		if errors.Is(err, os.ErrClosed) {
+		// Remove temp file on failed close, unless already closed.
+		if !errors.Is(err, os.ErrClosed) {
 			_ = os.Remove(f.TempName())
 		}
 		return err

--- a/atomicfile/atomicfile.go
+++ b/atomicfile/atomicfile.go
@@ -33,22 +33,15 @@ func Create(path string, mode os.FileMode) (*File, error) {
 
 // Close closes the file and renames it to the final name.
 func (f *File) Close() error {
-	err := f.File.Close()
-	if err != nil {
-		// Remove temp file on failed close, unless already closed.
-		if !errors.Is(err, os.ErrClosed) {
-			_ = os.Remove(f.TempName())
-		}
+	if err := f.closeTemp(); err != nil {
 		return err
 	}
-
 	return os.Rename(f.TempName(), f.Name())
 }
 
 // Discard closes the temproary file and removes it without renaming it.
 func (f *File) Discard() error {
-	if err := f.File.Close(); err != nil {
-		_ = os.Remove(f.TempName())
+	if err := f.closeTemp(); err != nil {
 		return err
 	}
 	return os.Remove(f.TempName())
@@ -62,4 +55,15 @@ func (f *File) Name() string {
 // TempName returns the temporary name of the file.
 func (f *File) TempName() string {
 	return f.File.Name()
+}
+
+func (f *File) closeTemp() error {
+	if err := f.File.Close(); err != nil {
+		// Remove temp file on failed close, unless already closed.
+		if !errors.Is(err, os.ErrClosed) {
+			_ = os.Remove(f.TempName())
+		}
+		return err
+	}
+	return nil
 }

--- a/atomicfile/atomicfile.go
+++ b/atomicfile/atomicfile.go
@@ -16,7 +16,7 @@ type File struct {
 // reading and writing, and returns the resulting file. The temporary file is
 // renamed to the given path when [Close] is called.
 func Create(path string, mode os.FileMode) (*File, error) {
-	f, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path))
+	f, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+"-")
 	if err != nil {
 		return nil, err
 	}

--- a/atomicfile/atomicfile_test.go
+++ b/atomicfile/atomicfile_test.go
@@ -17,7 +17,11 @@ func TestCreate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Discard()
+	defer func() {
+		if err := f.Discard(); err != nil && !errors.Is(err, os.ErrClosed) {
+			t.Fatal(err)
+		}
+	}()
 
 	if f.Name() != path {
 		t.Fatal("expected final name, got:", f.Name())
@@ -120,7 +124,9 @@ func TestFileExists(t *testing.T) {
 	if err = file.Close(); err != nil {
 		panic(err)
 	}
-	defer os.Remove(file.Name())
+	t.Cleanup(func() {
+		_ = os.Remove(file.Name())
+	})
 
 	mode := os.FileMode(0644)
 	f, err := atomicfile.Create(file.Name(), mode)
@@ -130,7 +136,9 @@ func TestFileExists(t *testing.T) {
 	if err = f.Close(); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(f.Name())
+	defer func() {
+		_ = os.Remove(f.Name())
+	}()
 
 	fi, err := os.Stat(f.Name())
 	if err != nil {
@@ -160,7 +168,9 @@ func TestDirExistsAtFilename(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	defer os.Remove(name)
+	t.Cleanup(func() {
+		_ = os.Remove(name)
+	})
 
 	f, err := atomicfile.Create(name, 0600)
 	if err != nil {

--- a/atomicfile/atomicfile_test.go
+++ b/atomicfile/atomicfile_test.go
@@ -1,0 +1,180 @@
+package atomicfile_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gammazero/fsutil"
+	"github.com/gammazero/fsutil/atomicfile"
+)
+
+func TestCreate(t *testing.T) {
+	mode := os.FileMode(0666)
+	path := filepath.Join(t.TempDir(), "testfile")
+	f, err := atomicfile.Create(path, mode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Discard()
+
+	if f.Name() != path {
+		t.Fatal("expected final name, got:", f.Name())
+	}
+	if f.TempName() == path {
+		t.Fatal("temp name should not equal final name")
+	}
+
+	_, err = f.Write([]byte("hello"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !fsutil.FileExists(f.TempName()) {
+		t.Fatalf("temp file should exist: %s", err)
+	}
+	if fsutil.FileExists(f.Name()) {
+		t.Fatal("file should not exist")
+	}
+	fi, err := os.Stat(f.TempName())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode() != mode {
+		t.Fatal("expected temp file to have mode", mode, "has", fi.Mode())
+	}
+
+	if err = f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := os.Remove(f.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	if fsutil.FileExists(f.TempName()) {
+		t.Fatal("temp file should not exist")
+	}
+	if !fsutil.FileExists(f.Name()) {
+		t.Fatalf("file should exist")
+	}
+
+	fi, err = os.Stat(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode() != mode {
+		t.Fatal("expected final file to have mode", mode, "has", fi.Mode())
+	}
+
+	err = f.Close()
+	if err == nil || !errors.Is(err, os.ErrClosed) {
+		t.Fatal("expected os.ErrClosed on Close after Close")
+	}
+}
+
+func TestDiscard(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "testfile")
+	f, err := atomicfile.Create(path, 0666)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = f.Write([]byte("hello"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = f.Discard()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if fsutil.FileExists(f.TempName()) {
+		t.Fatal("temp file should not exist")
+	}
+	if fsutil.FileExists(f.Name()) {
+		t.Fatal("file should not exist")
+	}
+
+	err = f.Discard()
+	if err == nil || !errors.Is(err, os.ErrClosed) {
+		t.Fatal("expected os.ErrClosed on Discard after Discard")
+	}
+
+	err = f.Close()
+	if err == nil || !errors.Is(err, os.ErrClosed) {
+		t.Fatal("expected os.ErrClosed on Close after Discard")
+	}
+}
+
+func TestFileExists(t *testing.T) {
+	dir := t.TempDir()
+	file, err := os.CreateTemp(dir, "somefile")
+	if err != nil {
+		panic("cannot create temp file")
+	}
+	if err = file.Close(); err != nil {
+		panic(err)
+	}
+	defer os.Remove(file.Name())
+
+	mode := os.FileMode(0644)
+	f, err := atomicfile.Create(file.Name(), mode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+
+	fi, err := os.Stat(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode() != mode {
+		t.Fatal("expected final file to have mode", mode, "has", fi.Mode())
+	}
+}
+
+func TestBadDirectory(t *testing.T) {
+	dir := t.TempDir()
+	name := filepath.Join(dir, "no-such-dir", "my-file")
+	f, err := atomicfile.Create(name, 0600)
+	if err == nil {
+		t.Fatal("expected error creating file in non-existent directory")
+	}
+	if f != nil {
+		t.Fatal("Create should return nil on error")
+	}
+}
+
+func TestDirExistsAtFilename(t *testing.T) {
+	dir := t.TempDir()
+	name := filepath.Join(dir, "testblocked")
+	err := os.Mkdir(name, 0700)
+	if err != nil {
+		panic(err)
+	}
+	defer os.Remove(name)
+
+	f, err := atomicfile.Create(name, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = f.Close()
+	if err == nil || !errors.Is(err, os.ErrExist) {
+		t.Fatalf("expected error %q, got: %s", os.ErrExist, err)
+	}
+	fi, err := os.Stat(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fi.IsDir() {
+		t.Fatal("file should not have replaced directory")
+	}
+}

--- a/atomicfile/doc.go
+++ b/atomicfile/doc.go
@@ -1,0 +1,5 @@
+// Package atomicfile creates a temporary file that is renamed to the specified
+// path when Close is called. The prevents creating a partially written file
+// when there are writes in progress or when there is a failure while writing
+// to the file.
+package atomicfile

--- a/fsutil.go
+++ b/fsutil.go
@@ -1,3 +1,4 @@
+// Package fsutil provides common file and directory checks.
 package fsutil
 
 import (


### PR DESCRIPTION
Package `atomicfile` creates a temporary file that is renamed to the specified path when `Close` is called. The prevents creating a partially written file when there are writes in progress or when there is a failure while writing to the file.